### PR TITLE
phdr: add code to parse program header type

### DIFF
--- a/lib/obuffer.ml
+++ b/lib/obuffer.ml
@@ -10,6 +10,7 @@ let fmt_string_as_hex_bytes str =
   String.concat " " (List.map aux chars)
 
 module PlatformAgnosticReader = struct
+  let seek t pos = t.index <- pos
   let advance t count = t.index <- t.index + count
 
   let validate_read buffer bytes =
@@ -43,6 +44,7 @@ end
 
 (* Module signature for little- and big-endian readers *)
 module type Reader = sig
+  val seek : buffer_ty -> int -> unit
   val advance : buffer_ty -> int -> unit
   val u8 : buffer_ty -> (Stdint.Uint8.t, string) result
   val u16 : buffer_ty -> (Stdint.Uint16.t, string) result
@@ -51,6 +53,7 @@ module type Reader = sig
 end
 
 module LittleEndianReader : Reader = struct
+  let seek t pos = PlatformAgnosticReader.seek t pos
   let advance t count = PlatformAgnosticReader.advance t count
   let u8 t = PlatformAgnosticReader.u8 t
 
@@ -83,6 +86,7 @@ module LittleEndianReader : Reader = struct
 end
 
 module BigEndianReader : Reader = struct
+  let seek t pos = PlatformAgnosticReader.seek t pos
   let advance t count = PlatformAgnosticReader.advance t count
   let u8 t = PlatformAgnosticReader.u8 t
 

--- a/lib/obuffer.mli
+++ b/lib/obuffer.mli
@@ -8,6 +8,7 @@ val fmt_string_as_hex_bytes : string -> string
 
 (* Generic reader that can read unsigned bytes and fixed-length strings *)
 module PlatformAgnosticReader : sig
+  val seek : buffer_ty -> int -> unit
   val advance : buffer_ty -> int -> unit
   val validate_read : buffer_ty -> int -> (buffer_ty, string) result
   val u8 : buffer_ty -> (Stdint.uint8, string) result
@@ -16,6 +17,7 @@ end
 
 (* Module signature for little- and big-endian readers *)
 module type Reader = sig
+  val seek : buffer_ty -> int -> unit
   val advance : buffer_ty -> int -> unit
   val u8 : buffer_ty -> (Stdint.uint8, string) result
   val u16 : buffer_ty -> (Stdint.uint16, string) result

--- a/lib/ofile.mli
+++ b/lib/ofile.mli
@@ -239,4 +239,17 @@ type elf_header_ty = {
 
 val os_abi_ty_to_string : elf_os_abi_ty -> string
 val elf_type_ty_to_string : elf_type_ty -> string
-val new_file : string -> (elf_header_ty, string) result
+
+type phdr_type_ty =
+  | PT_NULL
+  | PT_LOAD
+  | PT_DYNAMIC
+  | PT_INTERP
+  | PT_NOTE
+  | PT_SHLIB
+  | PT_PHDR
+  | PT_PROC
+
+type phdr_ty = { p_type : phdr_type_ty }
+
+val new_file : string -> (phdr_ty list * elf_header_ty, string) result

--- a/test/test-files/invalid-elf-descriptions/invalid-phdr-type.yaml
+++ b/test/test-files/invalid-elf-descriptions/invalid-phdr-type.yaml
@@ -1,0 +1,5 @@
+ehdr: !Ehdr
+  e_type:       ET_REL
+phdrtab:
+ - !Phdr
+   p_type: 7

--- a/test/test-files/valid-elf-descriptions/xlate-LSB-32.yaml
+++ b/test/test-files/valid-elf-descriptions/xlate-LSB-32.yaml
@@ -14,7 +14,7 @@ ehdr: !Ehdr
   e_flags:      [64, 8, 2, 1]
   e_ehsize:     0x0A0A
   e_phentsize:  0xB0B0
-  e_phnum:      0x0C0C
+  e_phnum:      0
   e_shentsize:  0xD0D0
   e_shnum:      0xFE0E
   e_shstrndx:   0xF0F0

--- a/test/test-files/valid-elf-descriptions/xlate-LSB-64.yaml
+++ b/test/test-files/valid-elf-descriptions/xlate-LSB-64.yaml
@@ -14,7 +14,7 @@ ehdr: !Ehdr
   e_flags:      [64, 8, 2, 1]
   e_ehsize:     0x0A0A
   e_phentsize:  0xB0B0
-  e_phnum:      0x0C0C
+  e_phnum:      0
   e_shentsize:  0xD0D0
   e_shnum:      0xFE0E
   e_shstrndx:   0xF0F0

--- a/test/test-files/valid-elf-descriptions/xlate-MSB-32.yaml
+++ b/test/test-files/valid-elf-descriptions/xlate-MSB-32.yaml
@@ -14,7 +14,7 @@ ehdr: !Ehdr
   e_flags:      [64, 8, 2, 1]
   e_ehsize:     0x0A0A
   e_phentsize:  0xB0B0
-  e_phnum:      0x0C0C
+  e_phnum:      0
   e_shentsize:  0xD0D0
   e_shnum:      0xFE0E
   e_shstrndx:   0xF0F0

--- a/test/test-files/valid-elf-descriptions/xlate-MSB-64.yaml
+++ b/test/test-files/valid-elf-descriptions/xlate-MSB-64.yaml
@@ -14,7 +14,7 @@ ehdr: !Ehdr
   e_flags:      [64, 8, 2, 1]
   e_ehsize:     0x0A0A
   e_phentsize:  0xB0B0
-  e_phnum:      0x0C0C
+  e_phnum:      0
   e_shentsize:  0xD0D0
   e_shnum:      0xFE0E
   e_shstrndx:   0xF0F0

--- a/test/tests.ml
+++ b/test/tests.ml
@@ -21,6 +21,10 @@ let negative_tests =
       error_message = "unknown ELF class: 03";
     };
     {
+      yaml_path = "test-files/invalid-elf-descriptions/invalid-phdr-type.yaml";
+      error_message = "unknown program header type: 0007";
+    };
+    {
       yaml_path = "test-files/invalid-elf-descriptions/invalid-phentsize-0.yaml";
       error_message = "invalid e_phentsize: 31";
     };


### PR DESCRIPTION
With this patch, the code now starts to parse program headers.
Subsequent patches will add a more complete program header parsing.