### PR TITLE
phdr: add complete program header parsing

### DIFF
--- a/lib/ofile.mli
+++ b/lib/ofile.mli
@@ -250,6 +250,15 @@ type phdr_type_ty =
   | PT_PHDR
   | PT_PROC
 
-type phdr_ty = { p_type : phdr_type_ty }
+type phdr_ty = {
+  p_type : phdr_type_ty;
+  p_offset : Stdint.uint64;
+  p_vaddr : Stdint.uint64;
+  p_paddr : Stdint.uint64;
+  p_filesz : Stdint.uint64;
+  p_memsz : Stdint.uint64;
+  p_flags : Stdint.uint32;
+  p_align : Stdint.uint64;
+}
 
 val new_file : string -> (phdr_ty list * elf_header_ty, string) result


### PR DESCRIPTION
This patch adds code to parse all fields of the program headers,
switching between field sequences for both ELF32 and ELF64 binaries.