### PR TITLE
shdr: validate shentsize after computing shdr_count

### DIFF
--- a/test/test-files/invalid-elf-descriptions/invalid-shentsize-2.yaml
+++ b/test/test-files/invalid-elf-descriptions/invalid-shentsize-2.yaml
@@ -1,0 +1,17 @@
+ehdr: !Ehdr
+  e_ident: !Ident
+    ei_class:     ELFCLASS32
+  e_type: ET_REL
+  e_shstrndx: 65537
+  e_shentsize:  39
+
+sections:
+ - !Section # index 0
+   sh_type: SHT_NULL
+
+ - !Section
+   sh_type: SHT_STRTAB
+   sh_index: 65537
+   sh_name: .shstrtab
+   sh_data:
+   - .shstrtab

--- a/test/test-files/invalid-elf-descriptions/invalid-shentsize-3.yaml
+++ b/test/test-files/invalid-elf-descriptions/invalid-shentsize-3.yaml
@@ -1,0 +1,17 @@
+ehdr: !Ehdr
+  e_ident: !Ident
+    ei_class:     ELFCLASS64
+  e_type: ET_REL
+  e_shstrndx: 65537
+  e_shentsize:  63
+
+sections:
+ - !Section # index 0
+   sh_type: SHT_NULL
+
+ - !Section
+   sh_type: SHT_STRTAB
+   sh_index: 65537
+   sh_name: .shstrtab
+   sh_data:
+   - .shstrtab

--- a/test/tests.ml
+++ b/test/tests.ml
@@ -45,6 +45,14 @@ let negative_tests =
       error_message = "invalid e_shentsize: 63";
     };
     {
+      yaml_path = "test-files/invalid-elf-descriptions/invalid-shentsize-2.yaml";
+      error_message = "invalid e_shentsize: 39";
+    };
+    {
+      yaml_path = "test-files/invalid-elf-descriptions/invalid-shentsize-3.yaml";
+      error_message = "invalid e_shentsize: 63";
+    };
+    {
       yaml_path = "test-files/invalid-elf-descriptions/invalid-shnum-0.yaml";
       error_message = "invalid e_shnum 3598 for e_shoff=0";
     };


### PR DESCRIPTION
Since section header counts can live outside the ELF header
(specifically, in the size field of the first section header), we need
to validate the section entry size _after_ fetching the true section
header count.  This patch moves the check after the section header count
is determined.