### PR TITLE
doc: [nfc] remove TODO section

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,6 @@ location information with instruction addresses, etc.
  - Supports both little- and big-endian encoding
 
 
-## TODO ##
-
- - Add code to parse section and program headers
- - Setup CI to run test suite
-
-
 ## Acknowledgements ##
 
  - [let-def/owee](https://github.com/let-def/owee): Owee is an excellent


### PR DESCRIPTION
Since the TODO section is outdated and because it will need constant
changes, this patch just drops it from the README file.  Perhaps GitHub
Issues are a better place to track TODO items.