### PR TITLE
sections: parse section names from headers

### DIFF
--- a/lib/obuffer.ml
+++ b/lib/obuffer.ml
@@ -40,6 +40,24 @@ module PlatformAgnosticReader = struct
     done;
     advance t length;
     Ok (Bytes.unsafe_to_string result)
+
+  let rec find_null t max count =
+    if count >= max then
+      let msg =
+        Printf.sprintf
+          "failed to find null termination at offset %d with bound %d" t.index
+          max
+      in
+      Error msg
+    else if t.byte_array.{t.index + count} = 0 then Ok count
+    else find_null t max (count + 1)
+
+  let null_terminated_string t max =
+    let open Base.Result.Monad_infix in
+    find_null t max 0 >>= fun null_idx ->
+    fixed_length_string t null_idx >>= fun result ->
+    advance t 1;
+    Ok result
 end
 
 (* Module signature for little- and big-endian readers *)

--- a/lib/obuffer.mli
+++ b/lib/obuffer.mli
@@ -13,6 +13,7 @@ module PlatformAgnosticReader : sig
   val validate_read : buffer_ty -> int -> (buffer_ty, string) result
   val u8 : buffer_ty -> (Stdint.uint8, string) result
   val fixed_length_string : buffer_ty -> int -> (string, string) result
+  val null_terminated_string : buffer_ty -> int -> (string, string) result
 end
 
 (* Module signature for little- and big-endian readers *)

--- a/lib/ofile.mli
+++ b/lib/ofile.mli
@@ -263,7 +263,7 @@ type phdr_ty = {
   p_align : Stdint.uint64;
 }
 
-type shdr_type_ty =
+type section_type_ty =
   | SHT_NULL
   | SHT_PROGBITS
   | SHT_SYMTAB
@@ -292,18 +292,18 @@ type shdr_type_ty =
   | SHT_PROC
   | SHT_USER
 
-type shdr_ty = {
-  sh_name : Stdint.uint32;
-  sh_type : shdr_type_ty;
-  sh_flags : Stdint.uint64;
-  sh_addr : Stdint.uint64;
-  sh_offset : Stdint.uint64;
-  sh_size : Stdint.uint64;
-  sh_link : Stdint.uint32;
-  sh_info : Stdint.uint32;
-  sh_addralign : Stdint.uint64;
-  sh_entsize : Stdint.uint64;
+type section_ty = {
+  name : string;
+  section_type : section_type_ty;
+  flags : Stdint.uint64;
+  addr : Stdint.uint64;
+  offset : Stdint.uint64;
+  size : Stdint.uint64;
+  link : Stdint.uint32;
+  info : Stdint.uint32;
+  addralign : Stdint.uint64;
+  entsize : Stdint.uint64;
 }
 
 val new_file :
-  string -> (elf_header_ty * phdr_ty list * shdr_ty list, string) result
+  string -> (elf_header_ty * phdr_ty list * section_ty list, string) result


### PR DESCRIPTION
This patch adds the initial code for looping over section headers to
determine the section name.